### PR TITLE
fix: format is row, col and not x, y

### DIFF
--- a/tests/expected_outputs/expected_output_5.txt
+++ b/tests/expected_outputs/expected_output_5.txt
@@ -1,1 +1,1 @@
-ERROR: Cannot place flower at already occupied location (2, 3)
+ERROR: Cannot place flower at already occupied location (3, 2)


### PR DESCRIPTION
From https://github.com/pontshomagane/CS144-SUTest-Cases:
`ERROR: Cannot place flower at already occupied location (<row>, <col>)`

However, the input is given as `x, y`
Thus, it should be `3, 2` instead of `2, 3`